### PR TITLE
Refactor dependencies

### DIFF
--- a/EventSourcingFramework/src/EventSourcingFramework.Application.Abstractions/Migrations/IMigrationTypeRegistry.cs
+++ b/EventSourcingFramework/src/EventSourcingFramework.Application.Abstractions/Migrations/IMigrationTypeRegistry.cs
@@ -4,5 +4,5 @@ public interface IMigrationTypeRegistry
 {
     void Register<TEntity>(int version, Type versionedType);
     Type GetVersionedType(Type targetType, int version);
-    Type? GetBaseType(Type targetType);
+    IReadOnlyCollection<Type> GetTypeToVersionedTypes(Type targetType);
 }

--- a/EventSourcingFramework/src/EventSourcingFramework.Infrastructure.Migrations/Services/MigrationTypeRegistry.cs
+++ b/EventSourcingFramework/src/EventSourcingFramework.Infrastructure.Migrations/Services/MigrationTypeRegistry.cs
@@ -11,18 +11,11 @@ public class MigrationTypeRegistry : IMigrationTypeRegistry
         versionMap[(typeof(TEntity), version)] = versionedType;
     }
 
-    public Type GetVersionedType(Type targetType, int version)
-    {
-        return versionMap[(targetType, version)];
-    }
+    public Type GetVersionedType(Type targetType, int version) => versionMap[(targetType, version)];
 
-    public Type? GetBaseType(Type targetType)
-    {
-        var versionedTypes = versionMap
-            .Where(kvp => kvp.Value == targetType)
-            .Select(kvp => kvp.Key.targetType)
-            .ToList();
-
-        return versionedTypes.FirstOrDefault();
-    }
+    public IReadOnlyCollection<Type> GetTypeToVersionedTypes(Type targetType) => 
+        versionMap
+        .Where(kvp => kvp.Key.targetType == targetType)
+        .Select(kvp => kvp.Value)
+        .ToList();
 }

--- a/EventSourcingFramework/src/EventSourcingFramework.Infrastructure.Shared/Interfaces/IEntityCollectionNameProvider.cs
+++ b/EventSourcingFramework/src/EventSourcingFramework.Infrastructure.Shared/Interfaces/IEntityCollectionNameProvider.cs
@@ -3,6 +3,7 @@ namespace EventSourcingFramework.Infrastructure.Shared.Interfaces;
 public interface IEntityCollectionNameProvider
 {
     void Register(Type type, string collectionName);
+    void RegisterMigrationTypes(Type baseType, Type migrationType);
     string GetCollectionName(Type type);
     IReadOnlyCollection<(Type Type, string CollectionName)> GetAllRegistered();
 }

--- a/EventSourcingFramework/src/EventSourcingFramework.Infrastructure/DI/DomainConfigurationExtensions.cs
+++ b/EventSourcingFramework/src/EventSourcingFramework.Infrastructure/DI/DomainConfigurationExtensions.cs
@@ -18,10 +18,18 @@ public static class DomainConfigurationExtensions
         
         configureDomain(schemaRegistry, migrationRegistry, migrator, mongoDbRegistrationService);
 
-        var collectionNameProvider = new EntityCollectionNameProvider(migrationRegistry);
+        var collectionNameProvider = new EntityCollectionNameProvider();
         var registered = mongoDbRegistrationService.GetRegistered();
         foreach (var (type, collectionName) in registered)
+        {
             collectionNameProvider.Register(type, collectionName);
+            foreach (var migrationType in migrationRegistry.GetTypeToVersionedTypes(type))
+            {
+                if (migrationType == type)
+                    continue;
+                collectionNameProvider.RegisterMigrationTypes(type, migrationType);
+            }
+        }
         
         services
             .AddSingleton<ISchemaVersionRegistry>(schemaRegistry)

--- a/EventSourcingFramework/tests/Integration/EventSourcingFramework.Infrastructure.Test.Integration/MongoDb/EntityCollectionNameProviderTests.cs
+++ b/EventSourcingFramework/tests/Integration/EventSourcingFramework.Infrastructure.Test.Integration/MongoDb/EntityCollectionNameProviderTests.cs
@@ -3,13 +3,14 @@ using EventSourcingFramework.Infrastructure.Migrations.Services;
 using EventSourcingFramework.Infrastructure.MongoDb.Services;
 using EventSourcingFramework.Infrastructure.Shared.Interfaces;
 using EventSourcingFramework.Test.Utilities;
+using EventSourcingFramework.Test.Utilities.Models;
 
 namespace EventSourcingFramework.Infrastructure.Test.Integration.MongoDb;
 
 [Collection("Integration")]
 public class EntityCollectionNameProviderTests : MongoIntegrationTestBase
 {
-    private readonly EntityCollectionNameProvider provider = new(new MigrationTypeRegistry());
+    private readonly EntityCollectionNameProvider provider = new();
 
     public EntityCollectionNameProviderTests(
         IMongoDbService mongoDbService,
@@ -77,6 +78,23 @@ public class EntityCollectionNameProviderTests : MongoIntegrationTestBase
         Assert.Equal(2, all.Count);
         Assert.Contains(all, x => x.Type == typeof(TestEntity1) && x.CollectionName == "Test1");
         Assert.Contains(all, x => x.Type == typeof(TestEntity2) && x.CollectionName == "Test2");
+    }
+    
+    [Fact]
+    public void RegisterMigrationTypes_Then_GetCollectionName_ResolvesBaseTypeCollection()
+    {
+        // Arrange
+        var baseType = typeof(TestEntity);
+        var migrationType = typeof(TestEntity1);
+
+        provider.Register(baseType, "BaseCollection");
+        provider.RegisterMigrationTypes(baseType, migrationType);
+
+        // Act
+        var actual = provider.GetCollectionName(migrationType);
+
+        // Assert
+        Assert.Equal("BaseCollection", actual);
     }
 
     private class TestEntity1


### PR DESCRIPTION
Make EntityCollectionNameProvider.cs not dependent on MigrationTypeRegistry.cs